### PR TITLE
Fixed a small typo that lead to the audio codec not being defined

### DIFF
--- a/src/extend-node-type.js
+++ b/src/extend-node-type.js
@@ -87,7 +87,7 @@ const transcodeNode = ({
           if (!audioCodec) {
             mutableChain = mutableChain.noAudio()
           } else {
-            mutableChain = mutableChain.withAudioCodec(audio)
+            mutableChain = mutableChain.withAudioCodec(audioCodec)
           }
 
           for (const option of options) {


### PR DESCRIPTION
Before this fix we were seeing:

```
success run static queries - 0.065 s — 4/4 80.29 queries/second
 ERROR 
UNHANDLED REJECTION audio is not defined
  ReferenceError: audio is not defined
  - extend-node-type.js:109 Object.transcode
    [website]/[gatsby-transformer-ffmpeg]/extend-node-type.js:109:56
  - index.js:99 
    [website]/[gatsby-plugin-ffmpeg]/lib/index.js:99:30
  - Array.forEach
  - index.js:88 processFile
    [website]/[gatsby-plugin-ffmpeg]/lib/index.js:88:8
⠴ run page queries — 1/14 1.03 queries/second
```